### PR TITLE
Fixed calculation of sample standard deviation

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,18 +71,18 @@ From our sample, we then calculate our sample mean ($\bar{x}$) and our sample st
 
 ```python
 x_bar = np.mean(sample_chol_levels)
-s = np.std(sample_chol_levels)
+s = np.std(sample_chol_levels, ddof=1)
 print(x_bar, s)
 ```
 
-    62.45 18.72291376896235
+    62.45 19.209304214912432
 
 
 We then calculate our interval estimate using a t-distribution and our various parameters. The t-distribution requires 4 parameters: 
-    * The sample mean
-    * The sample standard deviation
-    * The degrees of freedom (this is 1 less then the number of items in the sample)
-    * The confidence level we wish to have in our estimate
+* The sample mean
+* The sample standard deviation
+* The degrees of freedom (this is 1 less then the number of items in the sample)
+* The confidence level we wish to have in our estimate
 
 
 ```python
@@ -100,11 +100,11 @@ stats.t.interval(alpha = 0.95,                              # Confidence level
 
 
 
-    (23.26249111295013, 101.63750888704988)
+    (22.244464209742247, 102.65553579025776)
 
 
 
-Note that this confidence interval is particularly wide! In order to achieve a 95% confidence level we had to make a very general statement that we believe the average cholestoral level to be between 23 and 101.
+Note that this confidence interval is particularly wide! In order to achieve a 95% confidence level we had to make a very general statement that we believe the average cholestoral level to be between 22 and 102.
 
 As a preview of running further simulations to investigate some of these relationships, here is a similar dataset, generated at random, and the associated statistical techniques used to estimate the population mean. Note that with the large sample size, the sample point estimates are fairly accurate on their own. Despite this, the confidence interval is still quite large for the population mean. In part, this is due to a large standard deviation.
 
@@ -116,13 +116,13 @@ sample_chol_levels = np.random.normal(loc=54, scale=17, size=1000)
 
 ```python
 x_bar = np.mean(sample_chol_levels)
-s = np.std(sample_chol_levels)
+s = np.std(sample_chol_levels, ddof=1)
 print('Sample mean:', x_bar)
 print('Sample standard deviation:', s)
 ```
 
-    Sample mean: 54.34073433018943
-    Sample standard deviation: 16.822429793416344
+    Sample mean: 53.45517815445103
+    Sample standard deviation: 17.484460776839644
 
 
 
@@ -137,7 +137,7 @@ stats.t.interval(alpha = 0.95,                              # Confidence level
 
 
 
-    (21.32938286956194, 87.35208579081691)
+    (19.144695846497058, 87.76566046240501)
 
 
 

--- a/README.md
+++ b/README.md
@@ -66,12 +66,14 @@ sample_chol_levels = [66.0, 36.0, 73.0, 48.0, 81.0, 69.0, 75.0, 81.0, 73.0,
                       69.0, 101.0, 70.0, 50.0, 42.0, 36.0, 71.0, 65.0, 43.0, 76.0, 24.0]
 ```
 
-From our sample, we then calculate our sample mean ($\bar{x}$) and our sample standard deviation ($s$).
+From our sample, we then calculate our sample mean ($\bar{x}$) and our sample standard deviation ($s$). 
+
+We pass the parameter `ddof = 1` to `np.std` to make sure we correctly compute the standard deviation of the sample.
 
 
 ```python
 x_bar = np.mean(sample_chol_levels)
-s = np.std(sample_chol_levels, ddof=1)
+s = np.std(sample_chol_levels, ddof = 1)
 print(x_bar, s)
 ```
 
@@ -108,6 +110,8 @@ Note that this confidence interval is particularly wide! In order to achieve a 9
 
 As a preview of running further simulations to investigate some of these relationships, here is a similar dataset, generated at random, and the associated statistical techniques used to estimate the population mean. Note that with the large sample size, the sample point estimates are fairly accurate on their own. Despite this, the confidence interval is still quite large for the population mean. In part, this is due to a large standard deviation.
 
+Note we pass the parameter `ddof = 1` to `np.std` to make sure we correctly compute the standard deviation of the sample.
+
 
 ```python
 sample_chol_levels = np.random.normal(loc=54, scale=17, size=1000)
@@ -116,7 +120,7 @@ sample_chol_levels = np.random.normal(loc=54, scale=17, size=1000)
 
 ```python
 x_bar = np.mean(sample_chol_levels)
-s = np.std(sample_chol_levels, ddof=1)
+s = np.std(sample_chol_levels, ddof = 1)
 print('Sample mean:', x_bar)
 print('Sample standard deviation:', s)
 ```

--- a/index.ipynb
+++ b/index.ipynb
@@ -106,7 +106,7 @@
    "source": [
     "From our sample, we then calculate our sample mean ($\\bar{x}$) and our sample standard deviation ($s$). \n",
     "\n",
-    "To compute the **sample** standard deviation using NumPy, we pass the parameter `ddof = 1` to `np.std`."
+    "We pass the parameter `ddof = 1` to `np.std` to make sure we correctly compute the standard deviation of the sample."
    ]
   },
   {
@@ -124,7 +124,7 @@
    ],
    "source": [
     "x_bar = np.mean(sample_chol_levels)\n",
-    "s = np.std(sample_chol_levels, ddof=1)\n",
+    "s = np.std(sample_chol_levels, ddof = 1)\n",
     "print(x_bar, s)"
    ]
   },
@@ -182,7 +182,9 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "As a preview of running further simulations to investigate some of these relationships, here is a similar dataset, generated at random, and the associated statistical techniques used to estimate the population mean. Note that with the large sample size, the sample point estimates are fairly accurate on their own. Despite this, the confidence interval is still quite large for the population mean. In part, this is due to a large standard deviation."
+    "As a preview of running further simulations to investigate some of these relationships, here is a similar dataset, generated at random, and the associated statistical techniques used to estimate the population mean. Note that with the large sample size, the sample point estimates are fairly accurate on their own. Despite this, the confidence interval is still quite large for the population mean. In part, this is due to a large standard deviation.\n",
+    "\n",
+    "Note we pass the parameter `ddof = 1` to `np.std` to make sure we correctly compute the standard deviation of the sample."
    ]
   },
   {
@@ -210,7 +212,7 @@
    ],
    "source": [
     "x_bar = np.mean(sample_chol_levels)\n",
-    "s = np.std(sample_chol_levels, ddof=1)\n",
+    "s = np.std(sample_chol_levels, ddof = 1)\n",
     "print('Sample mean:', x_bar)\n",
     "print('Sample standard deviation:', s)"
    ]

--- a/index.ipynb
+++ b/index.ipynb
@@ -104,7 +104,9 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "From our sample, we then calculate our sample mean ($\\bar{x}$) and our sample standard deviation ($s$)."
+    "From our sample, we then calculate our sample mean ($\\bar{x}$) and our sample standard deviation ($s$). \n",
+    "\n",
+    "To compute the **sample** standard deviation using NumPy, we pass the parameter `ddof = 1` to `np.std`."
    ]
   },
   {

--- a/index.ipynb
+++ b/index.ipynb
@@ -1,1 +1,293 @@
-{"cells": [{"cell_type": "markdown", "metadata": {}, "source": ["# Confidence Intervals with T Distribution\n", "\n", "## Introduction\n", "\n", "We've started to take a look at confidence intervals, but our example doesn't match what typically happens in practice. That is, when we previously calculated confidence intervals, we assumed we knew the population standard deviation. This is extremely rare, after all, when do you know the population standard deviation but not the population mean? To solve this problem, we use what's known as a T distribution. T distributions are similar to the normal distribution in shape, but have heavier tails. T distributions also have a parameter known as **degrees of freedom**. The higher the degrees of freedom, the closer the distribution resembles that of the normal distribution. Here the normal distribution is pictured in blue with the current t-distribution in red and previous t-distributions (with lower degrees of freedom) in green.\n", "\n", "<img src=\"images/new_tdist_df.png\">\n", "\n", "## Objectives\n", "You will be able to:\n", "\n", "* Understand and explain the T-Distribution\n", "* Calculate and interpret confidence intervals"]}, {"cell_type": "markdown", "metadata": {}, "source": ["## Let's get started!\n", "\n", "As stated above, we are often trying to infer population parameter from a sample. As such, we typically don't know the population variance or standard deviation. To start, it is thus natural to use the standard deviation of our sample as an estimate for the standard deviation of our population.\n", "\n", "$S=\\sqrt{\\dfrac{1}{n-1}\\sum\\limits_{i=1}^n (X_i-\\bar{X})^2}$\n", "\n", "So when we go to find our confidence interval as before, our equation,\n", "\n", "$\\dfrac{\\bar{X}-\\mu}{\\sigma/\\sqrt{n}}\\sim N(0,1)$\n", "\n", "will become \n", "\n", "$\\dfrac{\\bar{X}-\\mu}{S/\\sqrt{n}}$\n", "\n", "(substituting S, the sample standard deviation, in for $\\sigma$\n", "\n", "\n", "As a result, our question now becomes how this quanitity is distributed.\n", "\n", "$T=\\dfrac{\\bar{X}-\\mu}{S/\\sqrt{n}}$\n", "\n", "While outside the scope of this discussion, it can be shown that this quantity can be modelled by a t distribution. (Hence the use of the letter $T$)."]}, {"cell_type": "markdown", "metadata": {}, "source": ["With this, you can calculate confidence intervals for the population mean with your sample alone by using the equation:  \n", "\n", "$\\bar{x}\\pm t_{\\alpha/2,n-1}\\left(\\dfrac{s}{\\sqrt{n}}\\right)$\n", "\n", "\n", "to review some vocabulary and terms:\n", "\n", "(1) $\\bar{x}$  is a \"point estimate\" of \u03bc\n", "\n", "(2)  $\\bar{x}\\pm t_{\\alpha/2,n-1}\\left(\\dfrac{s}{\\sqrt{n}}\\right)$ is an \"interval estimate\" of \u03bc\n", "\n", "(3) $\\dfrac{s}{\\sqrt{n}}$ is the \"standard error of the mean\"\n", "\n", "(4) $t_{\\alpha/2,n-1}\\left(\\dfrac{s}{\\sqrt{n}}\\right)$ is the \"margin of error\""]}, {"cell_type": "markdown", "metadata": {}, "source": ["Let's try this out in practice."]}, {"cell_type": "markdown", "metadata": {}, "source": ["First we start with a sample that we'll use to calculate the population mean with a 95% confidence."]}, {"cell_type": "code", "execution_count": 1, "metadata": {}, "outputs": [], "source": ["import numpy as np"]}, {"cell_type": "code", "execution_count": 2, "metadata": {}, "outputs": [], "source": ["sample_chol_levels = [66.0, 36.0, 73.0, 48.0, 81.0, 69.0, 75.0, 81.0, 73.0,\n", "                      69.0, 101.0, 70.0, 50.0, 42.0, 36.0, 71.0, 65.0, 43.0, 76.0, 24.0]"]}, {"cell_type": "markdown", "metadata": {}, "source": ["From our sample, we then calculate our sample mean ($\\bar{x}$) and our sample standard deviation ($s$)."]}, {"cell_type": "code", "execution_count": 3, "metadata": {}, "outputs": [{"name": "stdout", "output_type": "stream", "text": ["62.45 18.72291376896235\n"]}], "source": ["x_bar = np.mean(sample_chol_levels)\n", "s = np.std(sample_chol_levels)\n", "print(x_bar, s)"]}, {"cell_type": "markdown", "metadata": {}, "source": ["We then calculate our interval estimate using a t-distribution and our various parameters. The t-distribution requires 4 parameters: \n", "    * The sample mean\n", "    * The sample standard deviation\n", "    * The degrees of freedom (this is 1 less then the number of items in the sample)\n", "    * The confidence level we wish to have in our estimate"]}, {"cell_type": "code", "execution_count": 4, "metadata": {}, "outputs": [], "source": ["import scipy.stats as stats"]}, {"cell_type": "code", "execution_count": 5, "metadata": {}, "outputs": [{"data": {"text/plain": ["(23.26249111295013, 101.63750888704988)"]}, "execution_count": 5, "metadata": {}, "output_type": "execute_result"}], "source": ["stats.t.interval(alpha = 0.95,                              # Confidence level\n", "                 df= len(sample_chol_levels)-1,             # Degrees of freedom\n", "                 loc = x_bar,                               # Sample mean\n", "                 scale = s)                                 # Standard deviation estimate"]}, {"cell_type": "markdown", "metadata": {}, "source": ["Note that this confidence interval is particularly wide! In order to achieve a 95% confidence level we had to make a very general statement that we believe the average cholestoral level to be between 23 and 101."]}, {"cell_type": "markdown", "metadata": {}, "source": ["As a preview of running further simulations to investigate some of these relationships, here is a similar dataset, generated at random, and the associated statistical techniques used to estimate the population mean. Note that with the large sample size, the sample point estimates are fairly accurate on their own. Despite this, the confidence interval is still quite large for the population mean. In part, this is due to a large standard deviation."]}, {"cell_type": "code", "execution_count": 6, "metadata": {}, "outputs": [], "source": ["sample_chol_levels = np.random.normal(loc=54, scale=17, size=1000)"]}, {"cell_type": "code", "execution_count": 7, "metadata": {}, "outputs": [{"name": "stdout", "output_type": "stream", "text": ["Sample mean: 54.34073433018943\n", "Sample standard deviation: 16.822429793416344\n"]}], "source": ["x_bar = np.mean(sample_chol_levels)\n", "s = np.std(sample_chol_levels)\n", "print('Sample mean:', x_bar)\n", "print('Sample standard deviation:', s)"]}, {"cell_type": "code", "execution_count": 8, "metadata": {}, "outputs": [{"data": {"text/plain": ["(21.32938286956194, 87.35208579081691)"]}, "execution_count": 8, "metadata": {}, "output_type": "execute_result"}], "source": ["#Min and Max of Confidence Interval\n", "stats.t.interval(alpha = 0.95,                              # Confidence level\n", "                 df= len(sample_chol_levels)-1,             # Degrees of freedom\n", "                 loc = x_bar,                               # Sample mean\n", "                 scale = s)    "]}, {"cell_type": "markdown", "metadata": {}, "source": ["## Additional Resources\n", "\n", "https://onlinecourses.science.psu.edu/stat414/node/199/\u00a0\u00a0"]}, {"cell_type": "markdown", "metadata": {}, "source": ["## Summary\n", "\n", "In this lecture we investigated the more common method for calculating confidence intervals, as we will rarely know the population's standard deviation. As a result, we use the T distribution, allowing us to find estimates for the population mean even when not knowing any specific parameters concerning the population."]}], "metadata": {"kernelspec": {"display_name": "Python 3", "language": "python", "name": "python3"}, "language_info": {"codemirror_mode": {"name": "ipython", "version": 3}, "file_extension": ".py", "mimetype": "text/x-python", "name": "python", "nbconvert_exporter": "python", "pygments_lexer": "ipython3", "version": "3.7.3"}}, "nbformat": 4, "nbformat_minor": 2}
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Confidence Intervals with T Distribution\n",
+    "\n",
+    "## Introduction\n",
+    "\n",
+    "We've started to take a look at confidence intervals, but our example doesn't match what typically happens in practice. That is, when we previously calculated confidence intervals, we assumed we knew the population standard deviation. This is extremely rare, after all, when do you know the population standard deviation but not the population mean? To solve this problem, we use what's known as a T distribution. T distributions are similar to the normal distribution in shape, but have heavier tails. T distributions also have a parameter known as **degrees of freedom**. The higher the degrees of freedom, the closer the distribution resembles that of the normal distribution. Here the normal distribution is pictured in blue with the current t-distribution in red and previous t-distributions (with lower degrees of freedom) in green.\n",
+    "\n",
+    "<img src=\"images/new_tdist_df.png\">\n",
+    "\n",
+    "## Objectives\n",
+    "You will be able to:\n",
+    "\n",
+    "* Understand and explain the T-Distribution\n",
+    "* Calculate and interpret confidence intervals"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Let's get started!\n",
+    "\n",
+    "As stated above, we are often trying to infer population parameter from a sample. As such, we typically don't know the population variance or standard deviation. To start, it is thus natural to use the standard deviation of our sample as an estimate for the standard deviation of our population.\n",
+    "\n",
+    "$S=\\sqrt{\\dfrac{1}{n-1}\\sum\\limits_{i=1}^n (X_i-\\bar{X})^2}$\n",
+    "\n",
+    "So when we go to find our confidence interval as before, our equation,\n",
+    "\n",
+    "$\\dfrac{\\bar{X}-\\mu}{\\sigma/\\sqrt{n}}\\sim N(0,1)$\n",
+    "\n",
+    "will become \n",
+    "\n",
+    "$\\dfrac{\\bar{X}-\\mu}{S/\\sqrt{n}}$\n",
+    "\n",
+    "(substituting S, the sample standard deviation, in for $\\sigma$\n",
+    "\n",
+    "\n",
+    "As a result, our question now becomes how this quanitity is distributed.\n",
+    "\n",
+    "$T=\\dfrac{\\bar{X}-\\mu}{S/\\sqrt{n}}$\n",
+    "\n",
+    "While outside the scope of this discussion, it can be shown that this quantity can be modelled by a t distribution. (Hence the use of the letter $T$)."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "With this, you can calculate confidence intervals for the population mean with your sample alone by using the equation:  \n",
+    "\n",
+    "$\\bar{x}\\pm t_{\\alpha/2,n-1}\\left(\\dfrac{s}{\\sqrt{n}}\\right)$\n",
+    "\n",
+    "\n",
+    "to review some vocabulary and terms:\n",
+    "\n",
+    "(1) $\\bar{x}$  is a \"point estimate\" of μ\n",
+    "\n",
+    "(2)  $\\bar{x}\\pm t_{\\alpha/2,n-1}\\left(\\dfrac{s}{\\sqrt{n}}\\right)$ is an \"interval estimate\" of μ\n",
+    "\n",
+    "(3) $\\dfrac{s}{\\sqrt{n}}$ is the \"standard error of the mean\"\n",
+    "\n",
+    "(4) $t_{\\alpha/2,n-1}\\left(\\dfrac{s}{\\sqrt{n}}\\right)$ is the \"margin of error\""
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Let's try this out in practice."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "First we start with a sample that we'll use to calculate the population mean with a 95% confidence."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import numpy as np"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "sample_chol_levels = [66.0, 36.0, 73.0, 48.0, 81.0, 69.0, 75.0, 81.0, 73.0,\n",
+    "                      69.0, 101.0, 70.0, 50.0, 42.0, 36.0, 71.0, 65.0, 43.0, 76.0, 24.0]"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "From our sample, we then calculate our sample mean ($\\bar{x}$) and our sample standard deviation ($s$)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "62.45 19.209304214912432\n"
+     ]
+    }
+   ],
+   "source": [
+    "x_bar = np.mean(sample_chol_levels)\n",
+    "s = np.std(sample_chol_levels, ddof=1)\n",
+    "print(x_bar, s)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "We then calculate our interval estimate using a t-distribution and our various parameters. The t-distribution requires 4 parameters: \n",
+    "    * The sample mean\n",
+    "    * The sample standard deviation\n",
+    "    * The degrees of freedom (this is 1 less then the number of items in the sample)\n",
+    "    * The confidence level we wish to have in our estimate"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import scipy.stats as stats"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "(22.244464209742247, 102.65553579025776)"
+      ]
+     },
+     "execution_count": 5,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "stats.t.interval(alpha = 0.95,                              # Confidence level\n",
+    "                 df= len(sample_chol_levels)-1,             # Degrees of freedom\n",
+    "                 loc = x_bar,                               # Sample mean\n",
+    "                 scale = s)                                 # Standard deviation estimate"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Note that this confidence interval is particularly wide! In order to achieve a 95% confidence level we had to make a very general statement that we believe the average cholestoral level to be between 22 and 102."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "As a preview of running further simulations to investigate some of these relationships, here is a similar dataset, generated at random, and the associated statistical techniques used to estimate the population mean. Note that with the large sample size, the sample point estimates are fairly accurate on their own. Despite this, the confidence interval is still quite large for the population mean. In part, this is due to a large standard deviation."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "sample_chol_levels = np.random.normal(loc=54, scale=17, size=1000)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Sample mean: 53.45517815445103\n",
+      "Sample standard deviation: 17.484460776839644\n"
+     ]
+    }
+   ],
+   "source": [
+    "x_bar = np.mean(sample_chol_levels)\n",
+    "s = np.std(sample_chol_levels, ddof=1)\n",
+    "print('Sample mean:', x_bar)\n",
+    "print('Sample standard deviation:', s)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "(19.144695846497058, 87.76566046240501)"
+      ]
+     },
+     "execution_count": 8,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "#Min and Max of Confidence Interval\n",
+    "stats.t.interval(alpha = 0.95,                              # Confidence level\n",
+    "                 df= len(sample_chol_levels)-1,             # Degrees of freedom\n",
+    "                 loc = x_bar,                               # Sample mean\n",
+    "                 scale = s)    "
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Additional Resources\n",
+    "\n",
+    "https://onlinecourses.science.psu.edu/stat414/node/199/  "
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Summary\n",
+    "\n",
+    "In this lecture we investigated the more common method for calculating confidence intervals, as we will rarely know the population's standard deviation. As a result, we use the T distribution, allowing us to find estimates for the population mean even when not knowing any specific parameters concerning the population."
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.6.6"
+  },
+  "toc": {
+   "base_numbering": 1,
+   "nav_menu": {},
+   "number_sections": true,
+   "sideBar": true,
+   "skip_h1_title": false,
+   "title_cell": "Table of Contents",
+   "title_sidebar": "Contents",
+   "toc_cell": false,
+   "toc_position": {},
+   "toc_section_display": true,
+   "toc_window_display": false
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}

--- a/index.ipynb
+++ b/index.ipynb
@@ -131,10 +131,10 @@
    "metadata": {},
    "source": [
     "We then calculate our interval estimate using a t-distribution and our various parameters. The t-distribution requires 4 parameters: \n",
-    "    * The sample mean\n",
-    "    * The sample standard deviation\n",
-    "    * The degrees of freedom (this is 1 less then the number of items in the sample)\n",
-    "    * The confidence level we wish to have in our estimate"
+    "* The sample mean\n",
+    "* The sample standard deviation\n",
+    "* The degrees of freedom (this is 1 less then the number of items in the sample)\n",
+    "* The confidence level we wish to have in our estimate"
    ]
   },
   {


### PR DESCRIPTION
Changelog: 

1. Fixed the computation of the sample standard deviation in both examples by passing `ddof=1` to `np.std`, since we are computing sample standard deviations. 

2. Fixed reference to results in text below one of the answers. 

